### PR TITLE
Add the javascript string format that uses backticks

### DIFF
--- a/javascript.c
+++ b/javascript.c
@@ -102,6 +102,12 @@ int yed_plugin_boot(yed_plugin *self) {
                     REGEX("\\\\.");
                 APOP();
             ENDRANGE("\'");
+    
+            RANGE("`"); ONELINE(); SKIP("\\\\`");
+                APUSH("&code-escape");
+                    REGEX("\\\\.");
+                APOP();
+            ENDRANGE("`");
         APOP();
 
         APUSH("&code-fn-call");


### PR DESCRIPTION
Javascript allows strings that use backticks for formatted strings, I wanted this to be highlighted properly.